### PR TITLE
Add in-memory caching for repeated API calls

### DIFF
--- a/kraken/conditions.py
+++ b/kraken/conditions.py
@@ -13,6 +13,14 @@ class RequiredCheckRun(BaseModel):
     def description(self) -> str:
         return f"check-run {self.name}"
 
+    def __call__(self, commit: Commit, client: Client) -> bool:
+        check_runs = client.get_check_runs(ref=commit.sha)
+        return any(
+            check_run.name == self.name
+            and check_run.conclusion == CheckRunConclusion.SUCCESS
+            for check_run in check_runs
+        )
+
 
 class RequiredDeploy(BaseModel):
     type: Literal["deploy"]
@@ -22,57 +30,25 @@ class RequiredDeploy(BaseModel):
     def description(self) -> str:
         return f"deploy to {self.environment}"
 
+    def __call__(self, commit: Commit, client: Client) -> bool:
+        commits = {commit.sha} | {
+            c.sha for c in reversed(client.get_commits_after(ref=commit.sha))
+        }
+        for sha in commits:
+            deployment = client.get_latest_deployment(
+                environment=self.environment, ref=sha
+            )
+            if deployment and deployment.is_done:
+                return True
+
+        return False
+
 
 Condition = RequiredCheckRun | RequiredDeploy
-
-
-def check_check_run(
-    *, client: Client, condition: RequiredCheckRun, commit: Commit
-) -> bool:
-
-    check_runs = client.get_check_runs(ref=commit.sha)
-
-    return any(
-        check_run.name == condition.name
-        and check_run.conclusion == CheckRunConclusion.SUCCESS
-        for check_run in check_runs
-    )
-
-
-def check_deploy(*, client: Client, condition: RequiredDeploy, commit: Commit) -> bool:
-
-    commits = {commit.sha} | {
-        c.sha for c in reversed(client.get_commits_after(ref=commit.sha))
-    }
-
-    for sha in commits:
-        deployment = client.get_latest_deployment(
-            environment=condition.environment, ref=sha
-        )
-        if deployment and deployment.is_done:
-            return True
-
-    return False
-
-
-def check_condition(*, client: Client, condition: Condition, commit: Commit) -> bool:
-    if isinstance(condition, RequiredDeploy):
-        result = check_deploy(client=client, condition=condition, commit=commit)
-    elif isinstance(condition, RequiredCheckRun):
-        result = check_check_run(client=client, condition=condition, commit=commit)
-    else:
-        raise RuntimeError(f"Unsupported condition: {condition}")
-
-    if not result:
-        print(f'Condition "{condition.description}" not satisfied')
-
-    return result
 
 
 def check_conditions(
     *, client: Client, conditions: list[Condition], commit: Commit
 ) -> bool:
-    return all(
-        check_condition(client=client, condition=condition, commit=commit)
-        for condition in conditions
-    )
+
+    return all(condition(client=client, commit=commit) for condition in conditions)

--- a/kraken/github/client.py
+++ b/kraken/github/client.py
@@ -1,3 +1,4 @@
+import functools
 import itertools
 import json
 from typing import Any, Protocol
@@ -34,6 +35,7 @@ class GithubClient:
         self.base_url = base_url
         self.token = token
 
+    @functools.cache  # noqa: B019
     def get_latest_deployment(
         self, *, environment: str, ref: str | None = None
     ) -> Deployment | None:
@@ -62,6 +64,7 @@ class GithubClient:
 
         return Deployment.parse_obj(deployment)
 
+    @functools.cache  # noqa: B019
     def get_commits(self, *, page: int = 1) -> list[Commit]:
 
         data = self._request(
@@ -70,6 +73,7 @@ class GithubClient:
 
         return parse_obj_as(list[Commit], data)
 
+    @functools.cache  # noqa: B019
     def get_commits_after(self, *, ref: str) -> list[Commit]:
         commits: list[Commit] = []
         # Load commits until we find the last deployed commit
@@ -90,6 +94,7 @@ class GithubClient:
             data={"environment": environment, "ref": commit},
         )
 
+    @functools.cache  # noqa: B019
     def get_check_runs(self, *, ref: str) -> list[CheckRun]:
 
         response = self._request(


### PR DESCRIPTION
This way we don't request the checks for a commit each time we're checking if a certain commit passed.

Also clean up the checking code a bit